### PR TITLE
change not to should and add not to be.checked string

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/cypress/integration/paymentForm_spec.js
+++ b/cypress/integration/paymentForm_spec.js
@@ -49,7 +49,7 @@ describe("Payment Form", () => {
           if (index === $list.length - 1) {
             cy.wrap($el).should("be.checked");
           } else {
-            cy.wrap($el).not("be.checked");
+            cy.wrap($el).should("not.be.checked");
           }
         });
       });


### PR DESCRIPTION
The test to check if the fellows used the name attribute to group all the radio buttons wasn't working properly and they could have the radio buttons all with different values for the attribute or with no name attribute at all and still pass it. I made a change that gives the test the correct functionallity.